### PR TITLE
Feature/connect order and order event through factory

### DIFF
--- a/charmander/factories/order_event_factory.py
+++ b/charmander/factories/order_event_factory.py
@@ -3,11 +3,12 @@ Order Event Factory.
 
 """
 from microcosm.api import binding
-from microcosm_eventsource.factory import EventFactory
+from microcosm_eventsource.factory import EventFactory, EventInfo
 from microcosm_flask.namespaces import Namespace
 from microcosm_logging.decorators import logger
 
 from charmander.models.order_event_model import OrderEvent
+from charmander.models.order_event_type import OrderEventType
 
 
 @binding("order_event_factory")
@@ -22,4 +23,21 @@ class OrderEventFactory(EventFactory):
                 subject=OrderEvent,
                 version="v1",
             ),
+        )
+
+    def create_event(self, event_info,  **kwargs):
+        super().create_event(event_info, **kwargs)
+        if event_info.event_type == OrderEventType.OrderDeliveryDetailsAdded:
+            self.set_order_submitted(event_info)
+
+    def set_order_submitted(self, event_info):
+        submitted_info = EventInfo(
+            ns=event_info.ns,
+            sns_producer=event_info.sns_producer,
+            event_type=OrderEventType.OrderSubmitted,
+            parent=event_info.event,
+        )
+        self.create_transition(
+            submitted_info,
+            order_id=submitted_info.parent.order_id,
         )

--- a/charmander/models/order_event_model.py
+++ b/charmander/models/order_event_model.py
@@ -25,7 +25,7 @@ class OrderEvent(UnixTimestampEntityMixin, metaclass=EventMeta):
     __container__ = Order
     __unique_parent__ = True
 
-    customer_id = Column(UUIDType, nullable=False)
+    customer_id = Column(UUIDType, nullable=True)
     pizza_size = Column(EnumType(PizzaSize), nullable=True)
     crust_type = Column(EnumType(CrustType), nullable=True)
     topping_type = Column(EnumType(ToppingType), nullable=True)

--- a/charmander/models/order_event_type.py
+++ b/charmander/models/order_event_type.py
@@ -20,11 +20,13 @@ class OrderEventType(EventType):
 
     """
     # NB: Our state machines always start with an initial event
+    # order created
     OrderInitialized = event_info(
         follows=nothing(),
         requires=["customer_id"],
     )
 
+    # pizza created
     PizzaCreated = event_info(
         follows=any_of(
             "OrderInitialized",
@@ -41,6 +43,7 @@ class OrderEventType(EventType):
         ),
     )
 
+    # topping created
     PizzaToppingAdded = event_info(
         follows=any_of(
             "PizzaCreated",
@@ -54,6 +57,7 @@ class OrderEventType(EventType):
         ),
     )
 
+    # event initiated by user
     PizzaCustomizationFinished = event_info(
         follows=all_of(
             "PizzaCreated",
@@ -66,6 +70,7 @@ class OrderEventType(EventType):
         ),
     )
 
+    # by user (or an external event from some other service)
     OrderDeliveryDetailsAdded = event_info(
         follows=event("PizzaCustomizationFinished"),
         accumulate=compose(
@@ -74,6 +79,7 @@ class OrderEventType(EventType):
         ),
     )
 
+    # automatic after submitting details FOR NOW XXX
     OrderSubmitted = event_info(
         follows=event("OrderDeliveryDetailsAdded"),
         accumulate=compose(
@@ -82,6 +88,7 @@ class OrderEventType(EventType):
         ),
     )
 
+    # from some other service
     OrderFulfilled = event_info(
         follows=event("OrderSubmitted"),
         accumulate=compose(

--- a/charmander/models/pizza_model.py
+++ b/charmander/models/pizza_model.py
@@ -3,7 +3,7 @@ from enum import Enum, unique
 
 from microcosm_postgres.models import EntityMixin, Model
 from microcosm_postgres.types import EnumType
-from sqlalchemy import Column
+from sqlalchemy import Column, ForeignKey
 from sqlalchemy_utils import UUIDType
 
 
@@ -54,3 +54,8 @@ class Pizza(EntityMixin, Model):
     customer_id = Column(UUIDType, nullable=False)
     size = Column(EnumType(PizzaSize), nullable=False)
     crust_type = Column(EnumType(CrustType), nullable=False)
+    order_id = Column(
+        UUIDType,
+        ForeignKey("order.id"),
+        nullable=False,
+    )

--- a/charmander/models/topping_model.py
+++ b/charmander/models/topping_model.py
@@ -36,3 +36,8 @@ class Topping(EntityMixin, Model):
         nullable=False,
     )
     topping_type = Column(EnumType(ToppingType), nullable=False)
+    order_id = Column(
+        UUIDType,
+        ForeignKey("order.id"),
+        nullable=False,
+    )

--- a/charmander/resources/pizza_resources.py
+++ b/charmander/resources/pizza_resources.py
@@ -9,11 +9,13 @@ from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 from microcosm_flask.paging import PageSchema
 
+from charmander.models.order_model import Order
 from charmander.models.pizza_model import CrustType, Pizza, PizzaSize
 
 
 class NewPizzaSchema(Schema):
     customerId = fields.UUID(required=True, attribute="customer_id")
+    orderId = fields.UUID(required=True, attribute="order_id")
     size = EnumField(
         PizzaSize,
         required=True,
@@ -44,10 +46,20 @@ class PizzaSchema(NewPizzaSchema):
             ),
             pizza_id=obj.id,
         )
+        links["parent:order"] = Link.for_(
+            Operation.Retrieve,
+            Namespace(
+                subject=Order,
+                version="v1",
+            ),
+            order_id=obj.order_id,
+        )
+
         return links.to_dict()
 
 
 class SearchPizzaSchema(PageSchema):
     customer_id = fields.UUID()
+    order_id = fields.UUID()
     crust_type = EnumField(CrustType)
     size = EnumField(PizzaSize)

--- a/charmander/resources/topping_resources.py
+++ b/charmander/resources/topping_resources.py
@@ -9,12 +9,14 @@ from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 from microcosm_flask.paging import PageSchema
 
+from charmander.models.order_model import Order
 from charmander.models.pizza_model import Pizza
 from charmander.models.topping_model import Topping, ToppingType
 
 
 class NewToppingSchema(Schema):
     pizzaId = fields.UUID(required=True, attribute="pizza_id")
+    orderId = fields.UUID(required=True, attribute="order_id")
     toppingType = EnumField(ToppingType, required=True, attribute="topping_type")
 
 
@@ -45,10 +47,19 @@ class ToppingSchema(NewToppingSchema):
             ),
             pizza_id=obj.pizza_id,
         )
+        links["parent:order"] = Link.for_(
+            Operation.Retrieve,
+            Namespace(
+                subject=Order,
+                version="v1",
+            ),
+            order_id=obj.order_id,
+        )
 
         return links.to_dict()
 
 
 class SearchToppingSchema(PageSchema):
     pizza_id = fields.UUID()
+    order_id = fields.UUID()
     topping_type = EnumField(ToppingType)

--- a/charmander/routes/order/controller.py
+++ b/charmander/routes/order/controller.py
@@ -6,8 +6,8 @@ from microcosm.api import binding
 from microcosm_flask.conventions.crud_adapter import CRUDStoreAdapter
 from microcosm_flask.namespaces import Namespace
 
-from charmander.models.order_model import Order
 from charmander.models.order_event_type import OrderEventType
+from charmander.models.order_model import Order
 
 
 @binding("order_controller")
@@ -31,6 +31,7 @@ class OrderController(CRUDStoreAdapter):
             sns_producer=self.sns_producer,
             order_id=order.id,
             event_type=OrderEventType.OrderInitialized,
+            customer_id=order.customer_id,
         )
 
         return order

--- a/charmander/routes/order/controller.py
+++ b/charmander/routes/order/controller.py
@@ -7,6 +7,7 @@ from microcosm_flask.conventions.crud_adapter import CRUDStoreAdapter
 from microcosm_flask.namespaces import Namespace
 
 from charmander.models.order_model import Order
+from charmander.models.order_event_type import OrderEventType
 
 
 @binding("order_controller")
@@ -19,3 +20,17 @@ class OrderController(CRUDStoreAdapter):
             subject=Order,
             version="v1",
         )
+        self.sns_producer = graph.sns_producer
+        self.order_event_factory = graph.order_event_factory
+
+    def create(self, **kwargs):
+        order = super().create(**kwargs)
+
+        self.order_event_factory.create(
+            ns=None,
+            sns_producer=self.sns_producer,
+            order_id=order.id,
+            event_type=OrderEventType.OrderInitialized,
+        )
+
+        return order

--- a/charmander/routes/pizza/controller.py
+++ b/charmander/routes/pizza/controller.py
@@ -31,6 +31,9 @@ class PizzaController(CRUDStoreAdapter):
             sns_producer=self.sns_producer,
             order_id=pizza.order_id,
             event_type=OrderEventType.PizzaCreated,
+            pizza_size=pizza.size,
+            crust_type=pizza.crust_type,
+            customer_id=pizza.customer_id,
         )
 
         return pizza

--- a/charmander/routes/pizza/controller.py
+++ b/charmander/routes/pizza/controller.py
@@ -6,6 +6,7 @@ from microcosm.api import binding
 from microcosm_flask.conventions.crud_adapter import CRUDStoreAdapter
 from microcosm_flask.namespaces import Namespace
 
+from charmander.models.order_event_type import OrderEventType
 from charmander.models.pizza_model import Pizza
 
 
@@ -19,3 +20,17 @@ class PizzaController(CRUDStoreAdapter):
             subject=Pizza,
             version="v1",
         )
+        self.sns_producer = graph.sns_producer
+        self.order_event_factory = graph.order_event_factory
+
+    def create(self, **kwargs):
+        pizza = super().create(**kwargs)
+
+        self.order_event_factory.create(
+            ns=None,
+            sns_producer=self.sns_producer,
+            order_id=pizza.order_id,
+            event_type=OrderEventType.PizzaCreated,
+        )
+
+        return pizza

--- a/charmander/routes/topping/controller.py
+++ b/charmander/routes/topping/controller.py
@@ -6,6 +6,7 @@ from microcosm.api import binding
 from microcosm_flask.conventions.crud_adapter import CRUDStoreAdapter
 from microcosm_flask.namespaces import Namespace
 
+from charmander.models.order_event_type import OrderEventType
 from charmander.models.topping_model import Topping
 
 
@@ -19,3 +20,17 @@ class ToppingController(CRUDStoreAdapter):
             subject=Topping,
             version="v1",
         )
+        self.sns_producer = graph.sns_producer
+        self.order_event_factory = graph.order_event_factory
+
+    def create(self, **kwargs):
+        topping = super().create(**kwargs)
+
+        self.order_event_factory.create(
+            ns=None,
+            sns_producer=self.sns_producer,
+            order_id=topping.order_id,
+            event_type=OrderEventType.PizzaToppingAdded,
+        )
+
+        return topping

--- a/charmander/routes/topping/controller.py
+++ b/charmander/routes/topping/controller.py
@@ -31,6 +31,7 @@ class ToppingController(CRUDStoreAdapter):
             sns_producer=self.sns_producer,
             order_id=topping.order_id,
             event_type=OrderEventType.PizzaToppingAdded,
+            topping_type=topping.topping_type,
         )
 
         return topping

--- a/charmander/stores/pizza_store.py
+++ b/charmander/stores/pizza_store.py
@@ -17,6 +17,7 @@ class PizzaStore(Store):
             Pizza,
             auto_filter_fields=(
                 Pizza.customer_id,
+                Pizza.order_id,
                 Pizza.crust_type,
                 Pizza.size,
             ),

--- a/charmander/stores/topping_store.py
+++ b/charmander/stores/topping_store.py
@@ -17,6 +17,7 @@ class ToppingStore(Store):
             Topping,
             auto_filter_fields=(
                 Topping.pizza_id,
+                Topping.order_id,
                 Topping.topping_type,
             ),
         )

--- a/charmander/tests/routes/pizza/test_crud.py
+++ b/charmander/tests/routes/pizza/test_crud.py
@@ -19,8 +19,8 @@ from microcosm_postgres.identifiers import new_object_id
 from microcosm_postgres.operations import recreate_all
 
 from charmander.app import create_app
-from charmander.models.order_model import Order
 from charmander.models.order_event_type import OrderEventType
+from charmander.models.order_model import Order
 from charmander.models.pizza_model import CrustType, Pizza, PizzaSize
 
 

--- a/charmander/tests/routes/topping/test_crud.py
+++ b/charmander/tests/routes/topping/test_crud.py
@@ -19,6 +19,7 @@ from microcosm_postgres.identifiers import new_object_id
 from microcosm_postgres.operations import recreate_all
 
 from charmander.app import create_app
+from charmander.models.order_model import Order
 from charmander.models.pizza_model import CrustType, Pizza, PizzaSize
 from charmander.models.topping_model import Topping, ToppingType
 
@@ -31,9 +32,15 @@ class TestPizzaRoutes:
         self.uri = "/api/v1/topping"
         recreate_all(self.graph)
 
+        self.customer_id = new_object_id()
+
+        self.order = Order(
+            id=new_object_id(),
+            customer_id=self.customer_id,
+        )
         self.pizza = Pizza(
             id=new_object_id(),
-            customer_id=new_object_id(),
+            customer_id=self.customer_id,
             crust_type=CrustType.CHEESE_STUFFED,
             size=PizzaSize.LARGE,
         )
@@ -42,6 +49,9 @@ class TestPizzaRoutes:
             pizza_id=self.pizza.id,
             topping_type=ToppingType.PEPPERONI,
         )
+
+        with SessionContext(self.graph), transaction():
+            self.order.create()
 
     def teardown(self):
         self.graph.postgres.dispose()


### PR DESCRIPTION
Our event-oriented state machines include a special `factory` object which inherits from a class in `microcosm-eventsource`:  https://github.com/globality-corp/microcosm-eventsource/blob/develop/microcosm_eventsource/factory.py

The point of this factory is to centralize all logic around creating events. This has two key faces:
- Giving one place to add special logic for creating events
- Giving one place to call when you need to create events from within the service